### PR TITLE
Added tripcode setting, parsing, and signing messages with

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,15 @@ start - Join the chat (start receiving messages)
 stop - Leave the chat (stop receiving messages)
 users - Get list of users
 info - Get info about your account
+sign - Sign a message with your username
+s - Alias of sign
+tsign - Sign a message with your tripcode
+t - Alias of tsign
 motd - Show the welcome message
 version - Get version & source code of this bot
 modhelp - Show commands available to moderators
 adminhelp - Show commands available to admins
 toggledebug - Toggle debug mode (sends back all messages to you)
 togglekarma - Toggle karma notifications
+settripcode - Set a tripcode for your mesaages
 ```

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -10,7 +10,7 @@ allow_contacts: false
 # relay arbitrary documents (gifs always work)
 allow_documents: true
 
-# enable signing messages using /sign
+# enable signing messages using /sign or /tsign as well as setting a tripcode
 enable_signing: false
 # point of contact shown to blacklisted users
 #blacklist_contact: http://t.me/invite/something

--- a/src/database.py
+++ b/src/database.py
@@ -32,6 +32,7 @@ class User():
 		self.karma = None # int
 		self.hideKarma = None # bool
 		self.debugEnabled = None # bool
+		self.tripcode = None # str
 	def __eq__(self, other):
 		if type(other) == User:
 			return self.id == other.id
@@ -174,7 +175,7 @@ class JSONDatabase(Database):
 	def _userToDict(user):
 		props = ["id", "username", "realname", "rank", "joined", "left",
 			"lastActive", "cooldownUntil", "blacklistReason", "warnings",
-			"warnExpiry", "karma", "hideKarma", "debugEnabled"]
+			"warnExpiry", "karma", "hideKarma", "debugEnabled", "tripcode"]
 		d = {}
 		for prop in props:
 			value = getattr(user, prop)
@@ -272,7 +273,7 @@ class SQLiteDatabase(Database):
 	def _userToDict(user):
 		props = ["id", "username", "realname", "rank", "joined", "left",
 			"lastActive", "cooldownUntil", "blacklistReason", "warnings",
-			"warnExpiry", "karma", "hideKarma", "debugEnabled"]
+			"warnExpiry", "karma", "hideKarma", "debugEnabled", "tripcode"]
 		return {prop: getattr(user, prop) for prop in props}
 	@staticmethod
 	def _userFromRow(r):
@@ -305,6 +306,7 @@ CREATE TABLE IF NOT EXISTS `users` (
 	`karma` INTEGER NOT NULL,
 	`hideKarma` TINYINT NOT NULL,
 	`debugEnabled` TINYINT NOT NULL,
+	`tripcode` TEXT,
 	PRIMARY KEY (`id`)
 );
 			""".strip())

--- a/src/replies.py
+++ b/src/replies.py
@@ -30,6 +30,8 @@ types = NumericEnum([
 	"SUCCESS",
 	"BOOLEAN_CONFIG",
 	"SIGNED_MSG",
+	"TSIGNED_MSG",
+	"TRIPCODE_SET",
 
 	"CHAT_JOIN",
 	"CHAT_LEAVE",
@@ -53,6 +55,8 @@ types = NumericEnum([
 	"ERR_ALREADY_UPVOTED",
 	"ERR_UPVOTE_OWN_MESSAGE",
 	"ERR_SPAMMY",
+	"ERR_INVALID_TRIP_FORMAT",
+	"ERR_NO_TRIPCODE",
 
 	"USER_INFO",
 	"USER_INFO_MOD",
@@ -83,6 +87,9 @@ format_strs = {
 	types.BOOLEAN_CONFIG: lambda enabled, **_:
 		"<b>{description!x}</b>: " + (enabled and "enabled" or "disabled"),
 	types.SIGNED_MSG: "{text!x} <a href=\"tg://user?id={user_id}\">~~{user_text!x}</a>",
+	types.TSIGNED_MSG: "<b>{tripcode!x}</b>:\n"+
+			"{text!x}",
+	types.TRIPCODE_SET: "<b>Tripcode set to</b>: {trip!x}",
 
 	types.CHAT_JOIN: em("You joined the chat!"),
 	types.CHAT_LEAVE: em("You left the chat!"),
@@ -94,7 +101,7 @@ format_strs = {
 	types.PROMOTED_MOD: em("You've been promoted to moderator, run /modhelp for a list of commands."),
 	types.PROMOTED_ADMIN: em("You've been promoted to admin, run /adminhelp for a list of commands."),
 	types.KARMA_THANK_YOU: em("You just gave this user some sweet karma, awesome!"),
-	types.KARMA_NOTIFICATION: 
+	types.KARMA_NOTIFICATION:
 		em( "You've just been given sweet karma! (check /info to see your karma"+
 			" or /toggleKarma to turn these notifications off)" ),
 
@@ -112,10 +119,12 @@ format_strs = {
 	types.ERR_ALREADY_UPVOTED: em("You already upvoted this message."),
 	types.ERR_UPVOTE_OWN_MESSAGE: em("You can't upvote your own message."),
 	types.ERR_SPAMMY: em("Your message has not been sent. Avoid sending messages too fast, try again later."),
+	types.ERR_INVALID_TRIP_FORMAT: em("You tried to set an invalid tripcode, the format is `name#pass`."),
+	types.ERR_NO_TRIPCODE: em("You don't have a tripcode set."),
 
-	types.USER_INFO: lambda warnings, cooldown, **_:
+	types.USER_INFO: lambda warnings, cooldown, tripcode, **_:
 		"<b>id</b>: {id}, <b>username</b>: {username!x}, <b>rank</b>: {rank_i} ({rank}), "+
-		"<b>karma</b>: {karma}\n"+
+		"<b>karma</b>: {karma}, <b>tripcode</b>: " + ("{tripcode!t}\n" if tripcode is not None else "unset\n" ) +
 		"<b>warnings</b>: {warnings} " + smiley(warnings)+
 		( " (one warning will be removed on {warnExpiry!t})" if warnings > 0 else "" ) + ", "+
 		"<b>cooldown</b>: "+

--- a/src/replies.py
+++ b/src/replies.py
@@ -124,7 +124,7 @@ format_strs = {
 
 	types.USER_INFO: lambda warnings, cooldown, tripcode, **_:
 		"<b>id</b>: {id}, <b>username</b>: {username!x}, <b>rank</b>: {rank_i} ({rank}), "+
-		"<b>karma</b>: {karma}, <b>tripcode</b>: " + ("{tripcode!t}\n" if tripcode is not None else "unset\n" ) +
+		"<b>karma</b>: {karma}, <b>tripcode</b>: " + ("{tripcode!x}\n" if tripcode is not None else "unset\n" ) +
 		"<b>warnings</b>: {warnings} " + smiley(warnings)+
 		( " (one warning will be removed on {warnExpiry!t})" if warnings > 0 else "" ) + ", "+
 		"<b>cooldown</b>: "+

--- a/src/telegram.py
+++ b/src/telegram.py
@@ -42,7 +42,8 @@ def init(config, _db, _ch):
 	cmds = [
 		"start", "stop", "users", "info", "motd", "toggledebug", "togglekarma",
 		"version", "modhelp", "adminhelp", "modsay", "adminsay", "mod",
-		"admin", "warn", "delete", "uncooldown", "blacklist", "s", "sign"
+		"admin", "warn", "delete", "uncooldown", "blacklist", "s", "sign",
+		"settripcode", "t", "tsign"
 	]
 	for c in cmds: # maps /<c> to the function cmd_<c>
 		c = c.lower()
@@ -321,6 +322,15 @@ cmd_toggledebug = wrap_core(core.toggle_debug)
 cmd_togglekarma = wrap_core(core.toggle_karma)
 
 
+def cmd_settripcode(ev):
+	c_user = UserContainer(ev.from_user)
+	if " " not in ev.text:
+		return
+
+	arg = ev.text.split()[1]
+
+	return send_answer(ev, core.set_tripcode(c_user, arg), True)
+
 def cmd_modhelp(ev):
 	send_answer(ev, rp.Reply(rp.types.HELP_MODERATOR), True)
 
@@ -469,3 +479,18 @@ def cmd_sign(ev):
 	ch.saveMapping(c_user.id, msid, ev.message_id)
 
 cmd_s = cmd_sign # alias
+
+def cmd_tsign(ev):
+	c_user = UserContainer(ev.from_user)
+	if " " not in ev.text:
+		return
+
+	arg = ev.text[ev.text.find(" ")+1:].strip()
+
+	msid = core.send_tripsigned_user_message(c_user, calc_spam_score(ev), arg)
+	if type(msid) == rp.Reply:
+		return send_answer(ev, msid, True)
+
+	ch.saveMapping(c_user.id, msid, ev.message_id)
+
+cmd_t = cmd_tsign # alias

--- a/src/util.py
+++ b/src/util.py
@@ -1,3 +1,4 @@
+from crypt import crypt as tripcr
 import itertools
 import time
 import logging
@@ -71,3 +72,16 @@ class Enum():
 		return self._m.keys()
 	def values(self):
 		return self._m.values()
+
+def genTripcode(tripcode):
+	triphalves = tripcode.split('#')
+	trname = triphalves[0]
+	trpass = triphalves[1]
+
+	trpass_trunc = trpass[:8]
+
+	salt = (trpass_trunc + 'H.')[1:3]
+	trip_final = tripcr(trpass_trunc, salt)
+
+	formatted_trip = trname, " !" + trip_final[-10:]
+	return formatted_trip


### PR DESCRIPTION
I was under the impression the addition of /sign would be using tripcodes, so I added that,  it does the generation 4chan style output-wise.
I also added the sign commands to the readme since I noticed they were missing and made sure everything works and followed your indentation scheme.