### PR TITLE
Add Flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,16 @@ start - Join the chat (start receiving messages)
 stop - Leave the chat (stop receiving messages)
 users - Get list of users
 info - Get info about your account
+sign - Sign a message with your username
+s - Alias of sign
+tsign - Sign a message with your tripcode
+t - Alias of tsign
 motd - Show the welcome message
 version - Get version & source code of this bot
 modhelp - Show commands available to moderators
 adminhelp - Show commands available to admins
 toggledebug - Toggle debug mode (sends back all messages to you)
 togglekarma - Toggle karma notifications
+settripcode - Set a tripcode for your mesaages
+setflag - Set your flag
 ```

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -9,8 +9,9 @@ database: [sqlite, "path/to/secretlounge.db"]
 allow_contacts: false
 # relay arbitrary documents (gifs always work)
 allow_documents: true
-
-# enable signing messages using /sign
+# allow users to set a flag and display them above messages
+show_flags: false
+# enable signing messages using /sign or /tsign as well as setting a tripcode
 enable_signing: false
 # point of contact shown to blacklisted users
 #blacklist_contact: http://t.me/invite/something

--- a/src/core.py
+++ b/src/core.py
@@ -1,12 +1,15 @@
+# vim: set noet ts=4:
 import logging
 import time
 from datetime import datetime
 from threading import Lock
 
+from src.util import country_to_code, code_to_country, langcode_to_flag, flag_to_langcode
 import src.replies as rp
 from src.globals import *
 from src.database import User, SystemConfig
 from src.cache import CachedMessage
+from src.util import genTripcode
 
 db = None
 ch = None
@@ -14,15 +17,17 @@ spam_scores = None
 
 blacklist_contact = None
 enable_signing = None
+show_flags = None
 
 def init(config, _db, _ch):
-	global db, ch, spam_scores, blacklist_contact, enable_signing
+	global db, ch, spam_scores, blacklist_contact, enable_signing, show_flags
 	db = _db
 	ch = _ch
 	spam_scores = ScoreKeeper()
 
 	blacklist_contact = config.get("blacklist_contact", "")
 	enable_signing = config["enable_signing"]
+	show_flags = config["show_flags"]
 
 	# initialize db if empty
 	if db.getSystemConfig() is None:
@@ -184,6 +189,12 @@ def user_join(c_user):
 	user = User()
 	user.defaults()
 	user.id = c_user.id
+	if c_user.language_code == 'en-US':
+		user.flag = "us"
+	elif c_user.language_code is not None:
+		user.flag = c_user.language_code
+	else:
+		user.flag = "neutral"
 	updateUserFromEvent(user, c_user)
 	if not any(db.iterateUserIds()):
 		user.rank = RANKS.admin
@@ -217,11 +228,16 @@ def get_info(user):
 		"username": user.getFormattedName(),
 		"rank_i": user.rank,
 		"rank": RANKS.reverse[user.rank],
+		"tripcode": user.tripcode,
 		"karma": user.karma,
 		"warnings": user.warnings,
 		"warnExpiry": user.warnExpiry,
 		"cooldown": user.cooldownUntil if user.isInCooldown() else None,
 	}
+	if show_flags:
+		params["flag"] = langcode_to_flag(user.flag)
+	else:
+		params["flag"] = None
 	return rp.Reply(rp.types.USER_INFO, **params)
 
 @requireUser
@@ -283,6 +299,46 @@ def toggle_karma(user):
 		user.hideKarma = not user.hideKarma
 		new = user.hideKarma
 	return rp.Reply(rp.types.BOOLEAN_CONFIG, description="Karma notifications", enabled=not new)
+
+@requireUser
+def set_flag(user, flag):
+	if not show_flags:
+		return rp.Reply(rp.types.ERR_COMMAND_DISABLED)
+	if flag in ("gay","pirate","recycle","\U0001f3f3\U0000fe0f\U0000200d\U0001f308","\U00002620\U0000fe0f","\U0000267B\U0000fe0f"):
+		pass
+	elif "syria" in flag.lower():
+		flag = "sy"
+	elif len(flag) == 2:
+		check_flag = code_to_country(flag)
+		if check_flag is None:
+			try:
+				flag = flag_to_langcode(flag)
+			except ValueError:
+				if flag == "eu":
+					pass
+				else:
+					return rp.Reply(rp.types.ERR_INVALID_FLAG, flag=flag)
+	else:
+		check_flag = country_to_code(flag)
+		if check_flag is None:
+			return rp.Reply(rp.types.ERR_INVALID_FLAG, flag=flag)
+		else:
+			flag = check_flag
+	with db.modifyUser(id=user.id) as user:
+		user.flag = flag
+	return rp.Reply(rp.types.SET_FLAG, flag=langcode_to_flag(flag))
+
+@requireUser
+def set_tripcode(user, text):
+	if not enable_signing:
+		return rp.Reply(rp.types.ERR_COMMAND_DISABLED)
+
+	if not (0 < text.find("#") < len(text) - 1):
+		return rp.Reply(rp.types.ERR_INVALID_TRIP_FORMAT)
+
+	with db.modifyUser(id=user.id) as user:
+		user.tripcode = text
+	return rp.Reply(rp.types.TRIPCODE_SET, trip=genTripcode(text))
 
 @requireUser
 @requireRank(RANKS.admin)
@@ -407,7 +463,7 @@ def prepare_user_message(user, msg_score):
 	return ch.assignMessageId(CachedMessage(user.id))
 
 @requireUser
-def send_signed_user_message(user, msg_score, text):
+def send_signed_user_message(user, msg_score, text, tripcode=False):
 	if not enable_signing:
 		return rp.Reply(rp.types.ERR_COMMAND_DISABLED)
 	if user.isInCooldown():
@@ -415,7 +471,19 @@ def send_signed_user_message(user, msg_score, text):
 	ok = spam_scores.increaseSpamScore(user.id, msg_score)
 	if not ok:
 		return rp.Reply(rp.types.ERR_SPAMMY)
-	m = rp.Reply(rp.types.SIGNED_MSG, text=text, user_id=user.id, user_text=user.getFormattedName())
+
+	if tripcode:
+		if user.tripcode is None:
+			return rp.Reply(rp.types.ERR_NO_TRIPCODE)
+		if show_flags:
+			m = rp.Reply(rp.types.TSIGNED_MSG, text=text, user_id=user.id, tripcode=(genTripcode(user.tripcode) + " " + langcode_to_flag(user.flag)))
+		else:
+			m = rp.Reply(rp.types.TSIGNED_MSG, text=text, user_id=user.id, tripcode=genTripcode(user.tripcode))
+	else:
+		if show_flags:
+			text = langcode_to_flag(user.flag) + ":" + "\n" + text
+		m = rp.Reply(rp.types.SIGNED_MSG, text=text, user_id=user.id, user_text=user.getFormattedName())
+
 	msid = ch.assignMessageId(CachedMessage(user.id))
 	Sender.reply(m, msid, None, user, None)
 	return msid

--- a/src/core.py
+++ b/src/core.py
@@ -329,7 +329,6 @@ def set_flag(user, flag):
 	return rp.Reply(rp.types.SET_FLAG, flag=langcode_to_flag(flag))
 
 @requireUser
->>>>>>> f314cd875ae231052e56a332da6edc2ef1f2d3ac
 def set_tripcode(user, text):
 	if not enable_signing:
 		return rp.Reply(rp.types.ERR_COMMAND_DISABLED)

--- a/src/core.py
+++ b/src/core.py
@@ -464,7 +464,7 @@ def prepare_user_message(user, msg_score):
 	return ch.assignMessageId(CachedMessage(user.id))
 
 @requireUser
-def send_signed_user_message(user, msg_score, text, tripcode=False):
+def send_signed_user_message(user, msg_score, text, reply_msid=None, tripcode=False):
 	if not enable_signing:
 		return rp.Reply(rp.types.ERR_COMMAND_DISABLED)
 	if user.isInCooldown():
@@ -487,7 +487,7 @@ def send_signed_user_message(user, msg_score, text, tripcode=False):
 		m = rp.Reply(rp.types.SIGNED_MSG, text=text, user_id=user.id, user_text=user.getFormattedName())
 
 	msid = ch.assignMessageId(CachedMessage(user.id))
-	Sender.reply(m, msid, None, user, None)
+	Sender.reply(m, msid, None, user, reply_msid)
 	return msid
 
 # who is None -> to everyone except the user <except_who> (if applicable)

--- a/src/replies.py
+++ b/src/replies.py
@@ -1,3 +1,4 @@
+# vim: set noet ts=4:
 import re
 from string import Formatter
 
@@ -30,6 +31,7 @@ types = NumericEnum([
 	"SUCCESS",
 	"BOOLEAN_CONFIG",
 	"SIGNED_MSG",
+	"TSIGNED_MSG",
 
 	"CHAT_JOIN",
 	"CHAT_LEAVE",
@@ -40,6 +42,8 @@ types = NumericEnum([
 	"PROMOTED_ADMIN",
 	"KARMA_THANK_YOU",
 	"KARMA_NOTIFICATION",
+	"TRIPCODE_SET",
+	"SET_FLAG",
 
 	"ERR_COMMAND_DISABLED",
 	"ERR_NO_REPLY",
@@ -53,6 +57,10 @@ types = NumericEnum([
 	"ERR_ALREADY_UPVOTED",
 	"ERR_UPVOTE_OWN_MESSAGE",
 	"ERR_SPAMMY",
+	"ERR_INVALID_FLAG",
+	"ERR_INVALID_TRIP_FORMAT",
+	"ERR_INVALID_TRIPCODE",
+	"ERR_NO_TRIPCODE",
 
 	"USER_INFO",
 	"USER_INFO_MOD",
@@ -83,6 +91,8 @@ format_strs = {
 	types.BOOLEAN_CONFIG: lambda enabled, **_:
 		"<b>{description!x}</b>: " + (enabled and "enabled" or "disabled"),
 	types.SIGNED_MSG: "{text!x} <a href=\"tg://user?id={user_id}\">~~{user_text!x}</a>",
+	types.TSIGNED_MSG: "<b>{tripcode!x}</b>:\n"+
+			"{text!x}",
 
 	types.CHAT_JOIN: em("You joined the chat!"),
 	types.CHAT_LEAVE: em("You left the chat!"),
@@ -94,9 +104,11 @@ format_strs = {
 	types.PROMOTED_MOD: em("You've been promoted to moderator, run /modhelp for a list of commands."),
 	types.PROMOTED_ADMIN: em("You've been promoted to admin, run /adminhelp for a list of commands."),
 	types.KARMA_THANK_YOU: em("You just gave this user some sweet karma, awesome!"),
-	types.KARMA_NOTIFICATION: 
+	types.KARMA_NOTIFICATION:
 		em( "You've just been given sweet karma! (check /info to see your karma"+
 			" or /toggleKarma to turn these notifications off)" ),
+	types.TRIPCODE_SET: em("Tripcode set. It will appear as: ") + "{trip!x}",
+	types.SET_FLAG: "<b>Flag set to</b>: {flag!x}",
 
 	types.ERR_COMMAND_DISABLED: em("This command has been disabled."),
 	types.ERR_NO_REPLY: em("You need to reply to a message to use this command."),
@@ -112,11 +124,18 @@ format_strs = {
 	types.ERR_ALREADY_UPVOTED: em("You already upvoted this message."),
 	types.ERR_UPVOTE_OWN_MESSAGE: em("You can't upvote your own message."),
 	types.ERR_SPAMMY: em("Your message has not been sent. Avoid sending messages too fast, try again later."),
+	types.ERR_INVALID_FLAG: "{flag!x} <i>is not a valid flag</i>",
+	types.ERR_INVALID_TRIP_FORMAT:
+		em("You tried to set an invalid tripcode, the format is ")+
+		"<code>name#pass</code>" + em("."),
+	types.ERR_NO_TRIPCODE: em("You don't have a tripcode set."),
+	types.ERR_INVALID_FLAG: "{flag!x} " + em("is not a valid flag/country/country code."),
 
-	types.USER_INFO: lambda warnings, cooldown, **_:
-		"<b>id</b>: {id}, <b>username</b>: {username!x}, <b>rank</b>: {rank_i} ({rank}), "+
-		"<b>karma</b>: {karma}\n"+
-		"<b>warnings</b>: {warnings} " + smiley(warnings)+
+	types.USER_INFO: lambda warnings, cooldown, tripcode, flag, **_:
+		"<b>id</b>: {id}, <b>username</b>: {username!x}, <b>rank</b>: {rank_i} ({rank})\n"+
+		"<b>karma</b>: {karma}" + ( ", <b>flag</b>: {flag}" if flag is not None else "" ) + "\n" +
+		"<b>tripcode</b>: " + ("{tripcode!x}" if tripcode is not None else "unset" )  + "\n"+
+		"<b>warnings</b>: {warnings} " + smiley(warnings) +
 		( " (one warning will be removed on {warnExpiry!t})" if warnings > 0 else "" ) + ", "+
 		"<b>cooldown</b>: "+
 		( cooldown and "yes, until {cooldown!t}" or "no" ),

--- a/src/replies.py
+++ b/src/replies.py
@@ -57,9 +57,9 @@ types = NumericEnum([
 	"ERR_ALREADY_UPVOTED",
 	"ERR_UPVOTE_OWN_MESSAGE",
 	"ERR_SPAMMY",
-	"ERR_INVALID_FLAG",
 	"ERR_INVALID_TRIP_FORMAT",
 	"ERR_NO_TRIPCODE",
+	"ERR_INVALID_FLAG",
 
 	"USER_INFO",
 	"USER_INFO_MOD",
@@ -123,7 +123,6 @@ format_strs = {
 	types.ERR_ALREADY_UPVOTED: em("You already upvoted this message."),
 	types.ERR_UPVOTE_OWN_MESSAGE: em("You can't upvote your own message."),
 	types.ERR_SPAMMY: em("Your message has not been sent. Avoid sending messages too fast, try again later."),
-	types.ERR_INVALID_FLAG: "{flag!x} <i>is not a valid flag</i>",
 	types.ERR_INVALID_TRIP_FORMAT:
 		em("You tried to set an invalid tripcode, the format is ")+
 		"<code>name#pass</code>" + em("."),

--- a/src/telegram.py
+++ b/src/telegram.py
@@ -47,7 +47,7 @@ def init(config, _db, _ch):
 		"start", "stop", "users", "info", "motd", "toggledebug", "togglekarma",
 		"version", "source", "modhelp", "adminhelp", "modsay", "adminsay", "mod",
 		"admin", "warn", "delete", "uncooldown", "blacklist", "s", "sign",
-		"tripcode", "settripcode", "t", "tsign", "flag"
+		"tripcode", "settripcode", "t", "tsign", "setflag"
 	]
 	for c in cmds: # maps /<c> to the function cmd_<c>
 		c = c.lower()

--- a/src/telegram.py
+++ b/src/telegram.py
@@ -493,8 +493,13 @@ def relay(ev):
 @takesArgument()
 def cmd_sign(ev, arg):
 	c_user = UserContainer(ev.from_user)
+	reply_msid = None
+	if ev.reply_to_message is not None:
+		reply_msid = ch.lookupMapping(ev.from_user.id, data=ev.reply_to_message.message_id)
+		if reply_msid is None:
+			logging.warning("Message replied to not found in cache")
 
-	msid = core.send_signed_user_message(c_user, calc_spam_score(ev), arg)
+	msid = core.send_signed_user_message(c_user, calc_spam_score(ev), arg, reply_msid)
 	if type(msid) == rp.Reply:
 		return send_answer(ev, msid, True)
 
@@ -507,8 +512,13 @@ cmd_s = cmd_sign # alias
 @takesArgument()
 def cmd_tsign(ev, arg):
 	c_user = UserContainer(ev.from_user)
+	reply_msid = None
+	if ev.reply_to_message is not None:
+		reply_msid = ch.lookupMapping(ev.from_user.id, data=ev.reply_to_message.message_id)
+		if reply_msid is None:
+			logging.warning("Message replied to not found in cache")
 
-	msid = core.send_signed_user_message(c_user, calc_spam_score(ev), arg, tripcode=True)
+	msid = core.send_signed_user_message(c_user, calc_spam_score(ev), arg, reply_msid, tripcode=True)
 	if type(msid) == rp.Reply:
 		return send_answer(ev, msid, True)
 

--- a/src/util.py
+++ b/src/util.py
@@ -1,9 +1,13 @@
+# vim: set noet ts=4:
 import itertools
 import time
 import logging
+import json
+import csv
 from queue import PriorityQueue
 from threading import Lock
 from datetime import timedelta
+from crypt import crypt
 
 class Scheduler():
 	def __init__(self):
@@ -71,3 +75,75 @@ class Enum():
 		return self._m.keys()
 	def values(self):
 		return self._m.values()
+
+def country_to_code(country):
+	print(country)
+	country = country.title()
+	print(country)
+	dic = {}
+	with open("wikipedia-iso-country-codes.csv") as f:
+		file= csv.DictReader(f, delimiter=',')
+		for line in file:
+			dic[line['English short name lower case']] = line['Alpha-2 code']
+	country_list = [country]
+	try:
+		country_code = [dic[x] for x in country_list]
+	except KeyError:
+		return None
+	else:
+		return country_code[0]
+
+
+def code_to_country(code):
+	code = code.upper()
+	dic = {}
+	with open("wikipedia-iso-country-codes.csv") as f:
+		file= csv.DictReader(f, delimiter=',')
+		for line in file:
+			dic[line['English short name lower case']] = line['Alpha-2 code']
+		country = [k for k,v in dic.items() if v == code]
+		if country:
+			return country
+		else:
+			return None
+
+def langcode_to_flag(langcode):
+	if langcode in ("gay","pirate","recycle","\U0001f3f3\U0000fe0f\U0000200d\U0001f308","\U00002620\U0000fe0f","\U0000267B\U0000fe0f"):
+		if langcode in ("gay","\U0001f3f3\U0000fe0f\U0000200d\U0001f308"):
+			return "\U0001f3f3\U0000200d\U0001f308"
+		elif langcode in ("pirate","\U00002620\U0000fe0f"):
+			return "\U00002620"
+		elif langcode in ("recycle","\U0000267B\U0000fe0f"):
+			return "\U0000267B"
+		elif langcode == 'neutral':
+			return "\U0001f3f3"
+		elif langcode == "eu":
+			pass
+	offset = 127397
+	if langcode is not None:
+		cc = langcode.upper()
+	else:
+		return None
+	flag_list = []
+	for c in cc:
+		flag_list.append(chr(ord(c) + offset))
+	return "".join(flag_list)
+
+def flag_to_langcode(flag):
+	flag_point = [ord(x) for x in flag]
+	langcode = []
+	for f in flag_point:
+		flag_letter = f - 127397
+		langcode.append(chr(flag_letter))
+	return "".join(langcode)
+
+def genTripcode(tripcode):
+	# doesn't actually match 4chan's algorithm exactly
+	pos = tripcode.find("#")
+	trname = tripcode[:pos]
+	trpass = tripcode[pos+1:]
+
+	salt = (trpass[:8] + 'H.')[1:3]
+	trip_final = crypt(trpass[:8], salt)
+
+	return trname + " !" + trip_final[-10:]


### PR DESCRIPTION
This adds a configurable option to have a flag prepended to messages, or in the case of a trip code it will be appended to that, it also puts the flags in any messages supporting captions.

The flag is initialized by what telegram reports the user's langcode is, if any, and will otherwise set their flag to the neutral white flag, this happens regardless of if flags are enabled or not.

A user can set their flag with /setflag which accepts either

- The full ISO country name

- The ISO alpha-2 country code 

- The literal flag emoji of the country

An exception is made for Syria, which has a full name of "Syrian Arab Republic", I added specific handling for convenience.
The translation from country to code and vice versa is done with this csv http://geohack.net/gis/wikipedia-iso-country-codes.csv which needs to be downloaded separately, i didn't think it should just be in the repo even for people not using it which is why it's not included, but it's smaller than pycountry.
There are also three vanity flags included, the recycling symbol, the gay pride flag, and the skull and crossbones, there's an actual Jolly Roger flag coming in the unicode update and I will update to that when the time comes. 

Additionally there's a few changes with tripcode stuff, the relevant settings for your flag and tripcode will not display in /info if they aren't enabled, and in some cases crypt() will return None for a trip code so I added handling for that case.


Also some vim modelines. 