### PR TITLE
Link to other bots by reference

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -14,3 +14,15 @@ allow_documents: true
 enable_signing: false
 # point of contact shown to blacklisted users
 #blacklist_contact: http://t.me/invite/something
+
+# Make `>>>/N/` be converted to links to another bot specified
+allow_lounge_linking: false
+# Names used for lounge links
+lounge_links:
+    a: t.me/animeloungebot
+    b: t.me/secretloungebot
+    bier: t.me/bierloungebot
+    f: t.me/furryloungebot
+    g: t.me/techloungebot
+    lgbt: t.me/lgbtloungbot
+    pol: t.me/politicsloungebot

--- a/src/telegram.py
+++ b/src/telegram.py
@@ -204,7 +204,7 @@ def resend_message(chat_id, ev, reply_to=None):
 	if ev.content_type == "text":
 		try:
 			if ev.haslink:
-				return bot.send_message(chat_id, ev.text, parse_mode="markdown", **kwargs)
+				return bot.send_message(chat_id, ev.text, parse_mode="markdown", disable_web_page_preview=True, **kwargs)
 		except AttributeError:
 			return bot.send_message(chat_id, ev.text, **kwargs)
 	elif ev.content_type == "photo":


### PR DESCRIPTION
Is configurable to be disabled, you put in a list of names and links, then when you send `>>>/foo/` it matches that to a link. From what I've tried it shouldn't let people bypass removing bold and stuff.