### PR TITLE
Add "/delete_all" command

### DIFF
--- a/src/cache.py
+++ b/src/cache.py
@@ -46,6 +46,16 @@ class Cache():
 	def getMessage(self, msid):
 		with self.lock:
 			return self.msgs.get(msid, None)
+	def getMessagesByID(self, uid):
+		with self.lock:
+			if uid not in self.idmap.keys():
+				return None
+		return list(filter(lambda x:isinstance(x, int), self.idmap[uid].keys()))
+	def removeMessagesByID(self, uid):
+		with self.lock:
+			if uid not in self.idmap.keys():
+				return None
+		self.idmap[uid] = {}
 	def saveMapping(self, uid, msid, data):
 		with self.lock:
 			self._saveMapping(self.idmap, uid, msid, data)

--- a/src/core.py
+++ b/src/core.py
@@ -410,6 +410,25 @@ def delete_message(user, msid):
 
 @requireUser
 @requireRank(RANKS.admin)
+def delete_all_messages(user, msid):
+	if not allow_remove_command:
+		return rp.Reply(rp.types.ERR_COMMAND_DISABLED)
+
+	cm = ch.getMessage(msid)
+	if cm is None or cm.user_id is None:
+		return rp.Reply(rp.types.ERR_NOT_IN_CACHE)
+
+	user2 = db.getUser(id=cm.user_id)
+	_push_system_message(rp.Reply(rp.types.MESSAGE_DELETED_ALL), who=user2, reply_to=msid)
+	msgids = ch.getMessagesByID(cm.user_id)
+	for msid_ in msgids:
+		Sender.delete(msid_)
+	ch.removeMessagesByID(cm.user_id)
+	logging.info("%s deleted all messages from [%s]", user, user2.getObfuscatedId())
+	return rp.Reply(rp.types.SUCCESS)
+
+@requireUser
+@requireRank(RANKS.admin)
 def uncooldown_user(user, oid2=None, username2=None):
 	if oid2 is not None:
 		user2 = getUserByOid(oid2)

--- a/src/replies.py
+++ b/src/replies.py
@@ -36,6 +36,7 @@ types = NumericEnum([
 	"USER_NOT_IN_CHAT",
 	"GIVEN_COOLDOWN",
 	"MESSAGE_DELETED",
+	"MESSAGE_DELETED_ALL",
 	"PROMOTED_MOD",
 	"PROMOTED_ADMIN",
 	"KARMA_THANK_YOU",
@@ -100,6 +101,9 @@ format_strs = {
 	types.MESSAGE_DELETED:
 		em( "Your message has been deleted. No cooldown has been "
 			"given this time, but refrain from posting it again." ),
+	types.MESSAGE_DELETED_ALL:
+		em( "All your messages have been deleted. No cooldown has been"
+            "given this time, but refrain from spaming again."),
 	types.PROMOTED_MOD: em("You've been promoted to moderator, run /modhelp for a list of commands."),
 	types.PROMOTED_ADMIN: em("You've been promoted to admin, run /adminhelp for a list of commands."),
 	types.KARMA_THANK_YOU: em("You just gave this user some sweet karma, awesome!"),
@@ -170,7 +174,8 @@ format_strs = {
 		"  /admin &lt;username&gt; - promote an user to the admin rank\n"+
 		"\n"+
 		"<i>Or reply to a message and use</i>:\n"+
-		"  /blacklist [reason] - blacklist the user who sent this message",
+		"  /blacklist [reason] - blacklist the user who sent this message\n",
+		"  /delete_all - delete a all cached messages by the user"
 }
 
 localization = {}

--- a/src/telegram.py
+++ b/src/telegram.py
@@ -21,6 +21,7 @@ HIDE_FORWARD_FROM = set([
 	"AntiForwardedBot", "noforward_bot", "Anonymous_telegram_bot",
 	"Forwards_Cover_Bot", "ForwardsHideBot", "ForwardsCoversBot",
 	"NoForwardsSourceBot", "AntiForwarded_v2_Bot", "ForwardCoverzBot",
+
 ])
 VENUE_PROPS = ("title", "address", "foursquare_id", "foursquare_type", "google_place_id", "google_place_type")
 
@@ -66,8 +67,8 @@ def init(config, _db, _ch):
 	cmds = [
 		"start", "stop", "users", "info", "motd", "toggledebug", "togglekarma",
 		"version", "source", "modhelp", "adminhelp", "modsay", "adminsay", "mod",
-		"admin", "warn", "delete", "remove", "uncooldown", "blacklist", "s", "sign",
-		"tripcode", "t", "tsign"
+		"admin", "warn", "delete", "delete_all", "remove", "uncooldown", "blacklist",
+		"s", "sign", "tripcode", "t", "tsign"
 	]
 	for c in cmds: # maps /<c> to the function cmd_<c>
 		c = c.lower()
@@ -609,7 +610,7 @@ def cmd_admin(ev, arg):
 	arg = arg.lstrip("@")
 	send_answer(ev, core.promote_user(c_user, arg, RANKS.admin), True)
 
-def cmd_warn(ev, delete=False, only_delete=False):
+def cmd_warn(ev, delete=False, only_delete=False, delete_all=False):
 	c_user = UserContainer(ev.from_user)
 
 	if ev.reply_to_message is None:
@@ -620,6 +621,8 @@ def cmd_warn(ev, delete=False, only_delete=False):
 		return send_answer(ev, rp.Reply(rp.types.ERR_NOT_IN_CACHE), True)
 	if only_delete:
 		r = core.delete_message(c_user, reply_msid)
+	elif delete_all:
+		r = core.delete_all_messages(c_user, reply_msid)
 	else:
 		r = core.warn_user(c_user, reply_msid, delete)
 	send_answer(ev, r, True)
@@ -627,6 +630,8 @@ def cmd_warn(ev, delete=False, only_delete=False):
 cmd_delete = lambda ev: cmd_warn(ev, delete=True)
 
 cmd_remove = lambda ev: cmd_warn(ev, only_delete=True)
+
+cmd_delete_all = lambda ev: cmd_warn(ev, delete_all=True)
 
 @takesArgument()
 def cmd_uncooldown(ev, arg):


### PR DESCRIPTION
I'm running secretlounge instance for several months now and I see that it is hard to do anything about spam. Yes, you can ban users, but removing 100+ messages with `/remove` command is really time-consuming so i added `/delete_all` for admin to use. It removes all messages from given user without warn or balcklisting them. Hope someone will find this usefull and add it to main project.