### PR TITLE
Obfuscate karma totals into fixed buckets

### DIFF
--- a/src/database.py
+++ b/src/database.py
@@ -67,8 +67,11 @@ class User():
 		alpha = "0123456789abcdefghijklmnopqrstuv"
 		return ''.join(alpha[n%32] for n in (value, value>>5, value>>10, value>>15))
 	def getObfuscatedKarma(self):
-		offset = round(abs(self.karma * 0.2) + 2)
-		return self.karma + randint(0, offset + 1) - offset
+		if self.karma > 50 or self.karma < -50:
+			return max(-50, min(self.karma, 50))
+		if self.karma > 10 or self.karma < -10:
+			return max(-10, min(self.karma, 10))
+		return 0
 	def getFormattedName(self):
 		if self.username is not None:
 			return "@" + self.username

--- a/src/database.py
+++ b/src/database.py
@@ -67,9 +67,9 @@ class User():
 		alpha = "0123456789abcdefghijklmnopqrstuv"
 		return ''.join(alpha[n%32] for n in (value, value>>5, value>>10, value>>15))
 	def getObfuscatedKarma(self):
-		if self.karma > 50 or self.karma < -50:
+		if abs(self.karma) > 50:
 			return max(-50, min(self.karma, 50))
-		if self.karma > 10 or self.karma < -10:
+		if abs(self.karma) > 10:
 			return max(-10, min(self.karma, 10))
 		return 0
 	def getFormattedName(self):

--- a/src/replies.py
+++ b/src/replies.py
@@ -143,7 +143,7 @@ format_strs = {
 		( cooldown and "yes, until {cooldown!t}" or "no" ),
 	types.USER_INFO_MOD: lambda cooldown, **_:
 		"<b>id</b>: {id}, <b>username</b>: anonymous, <b>rank</b>: n/a, "+
-		"<b>karma</b>: {karma}\n"+
+		"<b>karma bracket</b>: {karma}\n"+
 		"<b>cooldown</b>: "+
 		( cooldown and "yes, until {cooldown!t}" or "no" ),
 	types.USERS_INFO: "<b>{count}</b> <i>users</i>",


### PR DESCRIPTION
Changes the `/info` command used by moderators so it returns karma only in buckets `-50, -10, 0, 10, 50`.

Satisfies #41.