### PR TITLE
Added admin rank requirement for setting motd/privacy text.

### DIFF
--- a/secretlounge_ng/core.py
+++ b/secretlounge_ng/core.py
@@ -304,6 +304,7 @@ def get_system_text(user: User, key: str):
 		return rp.Reply(rp.types.CUSTOM, text=v)
 
 @requireUser
+@requireRank(RANKS.admin)
 def set_system_text(user: User, key: str, arg: str):
 	if key not in ("motd", "privacy"):
 		raise ValueError()


### PR DESCRIPTION
A bug exists in commit fe93e93f477cf366494d8dd83f29babec0aae8c7 where any user can edit the text of `/motd`. Adding the `requireRank` annotation to that function corrects this.