### PR TITLE
Karma-based signing

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -27,6 +27,13 @@ enable_signing: false
 # defaults to 600 if not specified, set to 0 to disable
 #sign_limit_interval: 600
 
+# enable karma-based signing
+enable_sign_min_karma: false
+# minimum (inclusive) required amount of karma to allow signing
+# at 0, only users with negative karma (cooldowns?) won't be allowed to sign
+# this setting does not do anything if enable_sign_min_karma is false
+sign_min_karma: 0
+
 # point of contact shown to blacklisted users (optional)
 #blacklist_contact: http://t.me/invite/something
 

--- a/secretlounge_ng/core.py
+++ b/secretlounge_ng/core.py
@@ -33,13 +33,15 @@ class IUserContainer():
 		raise NotImplementedError()
 
 def init(config: dict, _db, _ch):
-	global db, ch, spam_scores, blacklist_contact, enable_signing, allow_remove_command, media_limit_period, sign_interval
+	global db, ch, spam_scores, blacklist_contact, enable_signing, allow_remove_command, media_limit_period, sign_interval, enable_sign_min_karma, sign_min_karma
 	db = _db
 	ch = _ch
 	spam_scores = ScoreKeeper()
 
 	blacklist_contact = config.get("blacklist_contact", "")
 	enable_signing = config["enable_signing"]
+	enable_sign_min_karma = config["enable_sign_min_karma"]
+	sign_min_karma = config["sign_min_karma"]
 	allow_remove_command = config["allow_remove_command"]
 	if "media_limit_period" in config.keys():
 		media_limit_period = timedelta(hours=int(config["media_limit_period"]))
@@ -537,6 +539,10 @@ def prepare_user_message(user: User, msg_score: int, *, is_media=False, signed=F
 		if last_used and (datetime.now() - last_used) < sign_interval:
 			return rp.Reply(rp.types.ERR_SPAMMY_SIGN)
 		sign_last_used[user.id] = datetime.now()
+
+	# enforce karma requirement
+	if signed and (enable_sign_min_karma and user.karma < sign_min_karma):
+		return rp.Reply(rp.types.ERR_LOW_KARMA)
 
 	return ch.assignMessageId(CachedMessage(user.id))
 

--- a/secretlounge_ng/core.py
+++ b/secretlounge_ng/core.py
@@ -24,6 +24,8 @@ enable_signing: bool = None
 allow_remove_command: bool = None
 media_limit_period: Optional[timedelta] = None
 sign_interval: timedelta = None
+enable_sign_min_karma: bool = None
+sign_min_karma: int = 0
 
 class IUserContainer():
 	id: int

--- a/secretlounge_ng/replies.py
+++ b/secretlounge_ng/replies.py
@@ -62,6 +62,7 @@ types = NumericEnum([
 	"ERR_NO_TRIPCODE",
 	"ERR_MEDIA_LIMIT",
 	"ERR_POLLS_UNSUPPORTED",
+	"ERR_LOW_KARMA",
 
 	"USER_INFO",
 	"USER_INFO_MOD",
@@ -135,6 +136,7 @@ format_strs = {
 	types.ERR_NO_TRIPCODE: em("You don't have a tripcode set."),
 	types.ERR_MEDIA_LIMIT: em("You can't send media or forward messages at this time, try again later."),
 	types.ERR_POLLS_UNSUPPORTED: em("Your message has not been sent. Polls are not supported, sorry."),
+	types.ERR_LOW_KARMA: em("You don't have the minimum amount of karma required to sign."),
 
 	types.USER_INFO: lambda warnings, cooldown, **_:
 		"<b>id</b>: {id}, <b>username</b>: {username!x}, <b>rank</b>: {rank_i} ({rank})\n"+


### PR DESCRIPTION
Implements a minimum requirement of karma to allow signing. Tripcodes are not touched by this.

Both the karma amount and the check itself are configurable from the `.yaml` but the properties must exist (no commenting them) or program will crash.